### PR TITLE
Implement communication unit

### DIFF
--- a/common/defines.vhd
+++ b/common/defines.vhd
@@ -17,12 +17,13 @@ package defines is
   subtype instruction_address_t is std_logic_vector(INSTRUCTION_ADDRESS_WIDTH - 1 downto 0);
   subtype instruction_t is std_logic_vector(INSTRUCTION_WIDTH - 1 downto 0);
   subtype memory_address_t is std_logic_vector(DATA_ADDRESS_WIDTH - 1 downto 0);
-  subtype thread_id_t is std_logic_vector(DATA_WIDTH - 1 downto 0);
+  subtype thread_id_t is std_logic_vector(ID_WIDTH - 1 downto 0);
 
   ---------------------------
   -- Ghettocuda parameters --
   ---------------------------
-  constant NUMBER_OF_STREAMING_PROCESSORS: integer := 16;
+  constant NUMBER_OF_STREAMING_PROCESSORS: integer := 2;
+  constant NUMBER_OF_STREAMING_PROCESSORS_BIT_WIDTH: integer := 1;
 
   --One block ram is 576 instructions
   constant INSTRUCTION_MEM_SIZE: integer := 576 * 10;
@@ -80,21 +81,21 @@ package defines is
   type sram_bus_control_t is
     record
       address : std_logic_vector(18 downto 0);
-      write_enable : std_logic;
+      write_enable_n : std_logic;
     end record;
 
   type sram_bus_data_t is
     record
       data : std_logic_vector(15 downto 0);
     end record;
-  
-  type ebi_control_t is 
+
+  type ebi_control_t is
     record
       address : std_logic_vector(DATA_ADDRESS_WIDTH - 1 downto 0);
-      write_enable : std_logic;
-      read_enable : std_logic;
-      chip_select_fpga : std_logic;
-      chip_select_sram : std_logic;
+      write_enable_n : std_logic;
+      read_enable_n : std_logic;
+      chip_select_fpga_n : std_logic;
+      chip_select_sram_n : std_logic;
     end record;
-  
+
 end package defines;

--- a/hardware/System.vhd
+++ b/hardware/System.vhd
@@ -4,7 +4,8 @@ use work.defines.all;
 
 entity System is
   Port ( -- Stuff
-         clk : in STD_LOGIC;
+         clk : in std_logic;
+         reset : in std_logic;
 
          -- SRAM
          sram_bus_data_1_inout : inout sram_bus_data_t;
@@ -25,7 +26,9 @@ entity System is
          ebi_control_in : in ebi_control_t;
          
          -- MC Special kernel complete flag
-         kernel_complete_out : out std_logic;
+         mc_kernel_complete_out : out std_logic;
+         
+         mc_sram_flip_in : in std_logic;
          
          -- MC SPI
          mc_spi_bus : inout spi_bus_t;
@@ -38,22 +41,19 @@ end System;
 architecture Behavioral of System is
 
   -- Communication unit
-  signal comm_sram_override_out : STD_LOGIC;
-  signal comm_sram_flip_out : STD_LOGIC;
-
   signal comm_sram_bus_data_inout : sram_bus_data_t;
   signal comm_sram_bus_control_out : sram_bus_control_t;
 
-  signal comm_instruction_data_out : instruction_t;
-  signal comm_instruction_address_out : STD_LOGIC_VECTOR(15 downto 0);
-  signal comm_instruction_write_enable_out : STD_LOGIC;
+  signal comm_instruction_data_out : word_t;
+  signal comm_instruction_address_out : std_logic_vector(INSTRUCTION_ADDRESS_WIDTH - 1 downto 0);
+  signal comm_instruction_write_enable_out : std_logic;
+  signal comm_instruction_address_hi_select_out : std_logic;
 
-  signal comm_reset_system_out : STD_LOGIC;
   signal comm_kernel_start_out: std_logic;
   signal comm_kernel_address_out: instruction_address_t;
   signal comm_kernel_number_of_threads_out: thread_id_t;
   
-  signal comm_constant_address_out: std_logic_vector(CONSTANT_MEM_LOG_SIZE -1 downto 0);
+  signal comm_constant_address_out: std_logic_vector(CONSTANT_MEM_LOG_SIZE - 1 downto 0);
   signal comm_constant_write_enable_out: std_logic;
   signal comm_constant_out: word_t;
   
@@ -68,7 +68,7 @@ begin
   ghettocuda : entity work.ghettocuda
   port map ( -- Stuff
             clk => clk,
-            reset => comm_reset_system_out,
+            reset => reset,
 
             -- Constant memory
             constant_write_data_in => comm_constant_out,
@@ -79,12 +79,13 @@ begin
             instruction_memory_data_in => comm_instruction_data_out,
             instruction_memory_address_in => comm_instruction_address_out,
             instruction_memory_write_enable_in => comm_instruction_write_enable_out,
+            instruction_memory_address_hi_select_in => comm_instruction_address_hi_select_out,
             
             -- Thread spawner
             ts_kernel_start_in => comm_kernel_start_out,
             ts_kernel_address_in => comm_kernel_address_out,
             ts_num_threads_in => comm_kernel_number_of_threads_out,
-            ts_kernel_complete_out => kernel_complete_out,
+            ts_kernel_complete_out => mc_kernel_complete_out,
             
             -- LSU
             load_store_sram_bus_data_1_inout => load_store_sram_bus_data_1_inout,
@@ -106,13 +107,10 @@ begin
             ebi_data_inout => ebi_data_inout,
             ebi_control_in => ebi_control_in,
 
-            command_sram_override_out => comm_sram_override_out,
-            command_sram_flip_out => comm_sram_flip_out,
-            system_reset_out => comm_reset_system_out,
-
             instruction_data_out => comm_instruction_data_out,
             instruction_address_out => comm_instruction_address_out,
             instruction_write_enable_out => comm_instruction_write_enable_out,
+            instruction_address_hi_select_out => comm_instruction_address_hi_select_out,
 
             sram_bus_data_inout => comm_sram_bus_data_inout,
             sram_bus_control_out => comm_sram_bus_control_out,
@@ -120,8 +118,6 @@ begin
             kernel_number_of_threads_out => comm_kernel_number_of_threads_out,
             kernel_start_out => comm_kernel_start_out,
             kernel_address_out => comm_kernel_address_out,
-            
-            comm_reset_system_out => comm_reset_system_out,
             
             constant_address_out => comm_constant_address_out,
             constant_write_enable_out => comm_constant_write_enable_out,
@@ -142,8 +138,7 @@ begin
             -- Communication unit wires
             comm_sram_bus_control_in => comm_sram_bus_control_out,
             comm_sram_bus_data_inout => comm_sram_bus_data_inout,
-            comm_sram_override => comm_sram_override_out,
-            comm_sram_flip_in => comm_sram_flip_out,
+            comm_sram_flip_in => mc_sram_flip_in,
 
             -- SRAM wires
             sram_bus_control_1_out => sram_bus_control_1_out,

--- a/hardware/communication_unit.vhd
+++ b/hardware/communication_unit.vhd
@@ -1,14 +1,13 @@
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
 use work.defines.all;
+use ieee.numeric_std.all;
 
 entity communication_unit is
   generic ( 
             CONSTANT_ADDRESS_WIDTH: integer := 4
   );
-  Port ( clk : in  STD_LOGIC;
-         system_reset_out: out STD_LOGIC;
-         comm_reset_system_out : out STD_LOGIC;
+  Port ( clk : in  std_logic;
 
          -- Thread Spawner signals
          kernel_start_out: out std_logic;
@@ -20,27 +19,56 @@ entity communication_unit is
          ebi_control_in : in ebi_control_t;
 
          -- Instruction memory
-         instruction_data_out : out instruction_t;
-         instruction_address_out : out  STD_LOGIC_VECTOR (15 downto 0);
-         instruction_write_enable_out : out  STD_LOGIC;
+         instruction_data_out : out word_t;
+         instruction_address_out : out  std_logic_vector(INSTRUCTION_ADDRESS_WIDTH - 1 downto 0);
+         instruction_write_enable_out : out  std_logic;
+         instruction_address_hi_select_out : out  std_logic;
 
          -- SRAM
-         command_sram_override_out : out  STD_LOGIC;
-         command_sram_flip_out : out  STD_LOGIC;
          sram_bus_data_inout : inout sram_bus_data_t;
          sram_bus_control_out: out sram_bus_control_t;
          
          -- Constant_storage
-         constant_address_out: out std_logic_vector(CONSTANT_ADDRESS_WIDTH -1 downto 0);
+         constant_address_out: out std_logic_vector(CONSTANT_MEM_LOG_SIZE - 1 downto 0);
          constant_write_enable_out: out std_logic;
          constant_out: out word_t
        );
 end communication_unit;
 
 architecture Behavioral of communication_unit is
-
 begin
 
+  -- Instruction memory
+  instruction_data_out <= ebi_data_inout;
+  instruction_address_out <= ebi_control_in.address(INSTRUCTION_ADDRESS_WIDTH downto 1);
+  instruction_address_hi_select_out <= ebi_control_in.address(0);
+  instruction_write_enable_out <= not ebi_control_in.write_enable_n 
+    and not ebi_control_in.chip_select_fpga_n 
+    and ebi_control_in.address(17);
+
+  -- Constant storage
+  constant_out <= ebi_data_inout;
+  constant_address_out <= ebi_control_in.address(CONSTANT_MEM_LOG_SIZE - 1 downto 0);
+  constant_write_enable_out <= not ebi_control_in.write_enable_n
+    and not ebi_control_in.chip_select_fpga_n
+    and not ebi_control_in.address(17);
+
+  -- SRAM
+  sram_bus_data_inout.data <= ebi_data_inout;
+  sram_bus_control_out.address <= ebi_control_in.address;
+  sram_bus_control_out.write_enable_n <= ebi_control_in.write_enable_n;
+  sram_bus_control_out.chip_select_n <= ebi_control_in.chip_select_sram_n;
+  
+  -- Thread spawner
+  kernel_number_of_threads_out <= std_logic_vector(shift_left(
+    resize(unsigned(ebi_data_inout), ID_WIDTH), 
+    NUMBER_OF_STREAMING_PROCESSORS_BIT_WIDTH + BARREL_HEIGHT_BIT_WIDTH
+  ));
+  kernel_address_out <= ebi_control_in.address(INSTRUCTION_ADDRESS_WIDTH - 1 downto 0);
+  kernel_start_out <= not ebi_control_in.write_enable_n
+    and not ebi_control_in.chip_select_fpga_n
+    and ebi_control_in.address(18);
+  
 
 end Behavioral;
 

--- a/hardware/ghettocuda.vhd
+++ b/hardware/ghettocuda.vhd
@@ -21,9 +21,10 @@ entity ghettocuda is
          constant_write_address_in : in std_logic_vector(CONSTANT_MEM_LOG_SIZE - 1 downto 0);
          
          -- Instruction memory
-         instruction_memory_data_in : in instruction_t;
+         instruction_memory_data_in : in word_t;
          instruction_memory_address_in : in std_logic_vector(INSTRUCTION_ADDRESS_WIDTH - 1 downto 0);
          instruction_memory_write_enable_in : in std_logic;
+         instruction_memory_address_hi_select_in : in std_logic;
          
          -- Thread spawner
          ts_kernel_start_in : in std_logic;
@@ -220,6 +221,7 @@ begin
             clk => clk, reset => reset,
             write_enable_in => instruction_memory_write_enable_in,
             address_in => mux_instruction_memory_address_in_out,
+            address_hi_select_in => instruction_memory_address_hi_select_in,
             data_in => instruction_memory_data_in,
             data_out => instruction_data_out);
 

--- a/hardware/instruction_memory.vhd
+++ b/hardware/instruction_memory.vhd
@@ -9,16 +9,21 @@ entity instruction_memory is
            reset : in std_logic;
            write_enable_in : in std_logic;
            address_in : in  instruction_address_t;
-           data_in : in instruction_t;
+           address_hi_select_in : in  std_logic;
+           data_in : in word_t;
            data_out : out instruction_t
            );
 end instruction_memory;
 
 architecture behavioral of instruction_memory is
-  type mem_t is array(INSTRUCTION_MEM_SIZE - 1 downto 0) of instruction_t;
-  signal inst_mem : mem_t := (others => (others => '0'));
+
+  type mem_t is array(INSTRUCTION_MEM_SIZE - 1 downto 0) of word_t;
+  signal inst_mem_hi : mem_t := (others => (others => '0'));
+  signal inst_mem_lo : mem_t := (others => (others => '0'));
+
 begin
-  data_out <= inst_mem(to_integer(unsigned(address_in)));
+
+  data_out <= inst_mem_lo(to_integer(unsigned(address_in))) & inst_mem_hi(to_integer(unsigned(address_in)));
 
   registers: process (clk) is
   begin
@@ -26,7 +31,11 @@ begin
     if rising_edge(clk) then
 
       if write_enable_in = '1' then
-        inst_mem(to_integer(unsigned(address_in))) <= data_in;
+        if address_hi_select_in = '1' then
+          inst_mem_hi(to_integer(unsigned(address_in))) <= data_in;
+        else
+          inst_mem_lo(to_integer(unsigned(address_in))) <= data_in;
+        end if;
       end if;
 
     end if;

--- a/hardware/sram_arbiter.vhd
+++ b/hardware/sram_arbiter.vhd
@@ -16,7 +16,6 @@ entity sram_arbiter is
          -- Communication unit wires
          comm_sram_bus_control_in : in sram_bus_control_t;
          comm_sram_bus_data_inout : inout sram_bus_data_t;
-         comm_sram_override : in std_logic;
          comm_sram_flip_in : in std_logic;
 
          -- SRAM wires

--- a/testbench/tb_instruction_memory.vhd
+++ b/testbench/tb_instruction_memory.vhd
@@ -13,7 +13,8 @@
   signal reset: std_logic;
   signal write_enable_in: std_logic;
   signal address_in: instruction_address_t;
-  signal data_in: instruction_t;
+  signal address_hi_select_in: std_logic;
+  signal data_in: word_t;
   signal data_out: instruction_t;
   
   constant clk_period: time := 10 ns;
@@ -25,6 +26,7 @@
             reset => reset,
             write_enable_in => write_enable_in,
             address_in => address_in,
+            address_hi_select_in => address_hi_select_in,
             data_in => data_in,
             data_out => data_out
       );
@@ -48,10 +50,18 @@
     reset <= '0';
     write_enable_in <= '1';
 
-    -- Write som data to memory
+    -- Write some data to memory
     for i in 0 to 20 loop
+      address_hi_select_in <= '0';
       address_in <= std_logic_vector(to_unsigned(i*20, INSTRUCTION_ADDRESS_WIDTH));
-      data_in <= std_logic_vector(to_unsigned(100 + i*5, INSTRUCTION_WIDTH));
+
+      data_in <= std_logic_vector(to_unsigned(10 + i*10, WORD_WIDTH));
+      wait for clk_period;
+      
+      address_hi_select_in <= '1';
+      address_in <= std_logic_vector(to_unsigned(i*20, INSTRUCTION_ADDRESS_WIDTH));
+
+      data_in <= std_logic_vector(to_unsigned(100 + i*5, WORD_WIDTH));
       wait for clk_period;
     end loop;
     -- Assert memory contents
@@ -59,7 +69,8 @@
     for i in 0 to 20 loop
       address_in <= std_logic_vector(to_unsigned(i*20, INSTRUCTION_ADDRESS_WIDTH));
       wait for clk_period;
-      assert_equals(std_logic_vector(to_unsigned(100 + i*5, INSTRUCTION_WIDTH)), data_out, "Checking memory contents");
+      assert_equals(std_logic_vector(to_unsigned(100 + i*5, WORD_WIDTH)), data_out(15 downto 0), "Checking memory contents upper bits");
+      assert_equals(std_logic_vector(to_unsigned(10 + i*10, WORD_WIDTH)), data_out(31 downto 16), "Checking memory contents lower bits");
     end loop;
 
     wait;


### PR DESCRIPTION
Changes instruction memory to write 16-bit halves, because of ebi bus limits.
Reading instruction memory functions as before.
